### PR TITLE
changed function visibility to prevent error in wp

### DIFF
--- a/include/ACFFieldOpenstreetmap/Core/Singleton.php
+++ b/include/ACFFieldOpenstreetmap/Core/Singleton.php
@@ -34,7 +34,7 @@ abstract class Singleton {
 	/**
 	 *	Prevent Instantinating
 	 */
-	private function __clone() { }
+	public function __clone() { }
 	private function __wakeup() { }
 
 	/**


### PR DESCRIPTION
changed  _clone () function visibility to public to prevent error messages in wordpress admin after update to php 8