### PR TITLE
Make magic method __wakeup() public for compatibility with php 8.0

### DIFF
--- a/include/ACFFieldOpenstreetmap/Core/Singleton.php
+++ b/include/ACFFieldOpenstreetmap/Core/Singleton.php
@@ -35,7 +35,7 @@ abstract class Singleton {
 	 *	Prevent Instantinating
 	 */
 	private function __clone() { }
-	private function __wakeup() { }
+	public function __wakeup() { }
 
 	/**
 	 *	Protected constructor


### PR DESCRIPTION
Version 1.3.2 of the plugin throws the following warning in PHP 8.0:

`Warning: The magic method ACFFieldOpenstreetmap\Core\Singleton::__wakeup() must have public visibility in /shared/httpd/thebrightpath/public/wp-content/plugins/acf-openstreetmap-field/include/ACFFieldOpenstreetmap/Core/Singleton.php on line 38`

The commit by @dsturm solves this issue.