### PR TITLE
Check that dispatchEvent exists and is a function before calling it

### DIFF
--- a/src/js/acf-input-osm.js
+++ b/src/js/acf-input-osm.js
@@ -991,7 +991,10 @@
 
 	// init when fields get loaded ...
 	acf.addAction( 'append', function( $el ){
-		$el.length && $el.get(0).dispatchEvent( new CustomEvent('acf-osm-map-added') );	
+		var el = $el.length && $el.get(0);
+		if (el && typeof el.dispatchEvent === 'function') {
+			el.dispatchEvent( new CustomEvent('acf-osm-map-added') );
+		}
 	});
 	// init when fields show ...
 	acf.addAction( 'show_field', function( field ) {


### PR DESCRIPTION
In the context of ACF blocks, rendered content being updated triggers the "append" action, but with a React component as the argument. React components don't have `dispatchEvent` (they're not DOM elements), so this function call errors and causes the block to fail to render. This change simply checks whether `dispatchEvent` exists before calling it.

If the argument to the "append" action is indeed an error in ACF, then if/when it gets fixed, this event will be properly dispatched again. Until then, it will simply do nothing when it would otherwise fail, which is at least an incremental improvement.

Fixes #100 